### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "express-rate-limit": "^8.2.1"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Fratch/FratchTV/security/code-scanning/2](https://github.com/Fratch/FratchTV/security/code-scanning/2)

The best way to fix this problem is to add a rate-limiting middleware to the affected route. In Express, the `express-rate-limit` package is the most popular solution for this. The fix involves:

- Installing `express-rate-limit` (if not already available).
- Requiring the package in the affected file (`index.js`).
- Creating a rate limiter instance with sensible defaults (e.g., max 100 requests per 15 minutes), which can be tuned according to the service requirements.
- Applying this rate limiter specifically to the `/videos` route, so that only that endpoint is protected without interfering with other routes.

Modification needs to occur at the top of `index.js` to require and initialize the rate limiter, and to add the middleware to the `/videos` GET route. Only the provided code in `index.js` should be changed; the rest of the application should remain functionally the same.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
