### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,15 @@ const videosLimiter = rateLimit({
     legacyHeaders: false,  // Disable the `X-RateLimit-*` headers
 });
 
-app.get('/', (req, res) => {
+// Set up rate limiter for root route: maximum 100 requests per 15 minutes per IP
+const rootLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+
+app.get('/', rootLimiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/Fratch/FratchTV/security/code-scanning/1](https://github.com/Fratch/FratchTV/security/code-scanning/1)

To fix the problem, we should apply a rate limiter middleware to the `'/'` route handler, just as is done for the `/videos` endpoint. This prevents excessive requests to the root path from triggering repeated disk accesses for the same file, mitigating denial-of-service risk via file system exhaustion.

Specifically, we need to:
- Create a rate limiter instance for the root route, using reasonable settings (e.g., max 100 requests per 15 minutes per IP).
- Add this limiter as middleware when handling `'/'`, i.e. change `app.get('/', (req, res) => ...` to `app.get('/', rootLimiter, (req, res) => ...`.
- Import and instantiate the limiter (already imported as `rateLimit`) similarly to the existing `videosLimiter`.

These changes only involve edits to index.js:
- Add a new root limiter configuration near where `videosLimiter` is defined.
- Insert that limiter into the middleware chain for `app.get('/')`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
