### PR TITLE
Add scheduling-based video selection, deterministic shuffle, and local tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/
@@ -129,6 +128,7 @@ dmypy.json
 .pyre/
 *.mp4
 .node_modules
+node_modules/
 .DS_Store
 *.mkv
 *.webm

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ These instructions will help you set up and run the Fratch TV application.
 
 ### Prerequisites
 
-Make sure you have Docker installed on your machine.
+- Node.js 18+ (for local development without Docker)
+- Docker (optional, only if you want to run via container)
 
 ### Building the Docker Image
 
@@ -22,6 +23,15 @@ docker build -t fratch-tv .
 docker run -p 1997:1997 fratch-tv
 ```
 
+### Running locally (no Docker)
+
+```bash
+npm install
+npm start
+```
+
+Open http://localhost:1997 in your browser.
+
 ## Usage
 Access the Fratch TV application by opening http://localhost:1997 in your web browser. The application allows you to play random videos with basic controls.
 
@@ -30,10 +40,22 @@ Access the Fratch TV application by opening http://localhost:1997 in your web br
 - index.js: Node.js server code that handles video playback and server configuration.
 - public/index.html: HTML file for the web page served by the Node.js server.
 - public/scripts/playVideos.js: JavaScript file containing the logic for playing videos randomly.
-- video/: Directory to store video files.
+- videos/: Directory to store video files.
 Additional Information
 The application uses Video.js for video playback.
-Video files are expected to be in the video/ directory and should have extensions like .mp4, .avi, .mkv, or .webm.
+### Scheduling folders
+
+FratchTV can load videos based on the current date/time. Create folders inside `videos/` using these rules:
+
+- `videos/<namedDateInterval>/<namedTimeInterval>/` (highest priority)
+- `videos/<namedDateInterval>/`
+- `videos/<namedTimeInterval>/`
+- `videos/default/` (fallback)
+
+Intervals are configured in `config.json`. For example, during `natale` + `sera`, videos inside
+`videos/natale/sera` are added first, then `videos/natale`, then `videos/sera`, then `videos/default`.
+
+Video files should have extensions like `.mp4`, `.avi`, `.mkv`, or `.webm`.
 
 ## License
 This project is licensed under the MIT License - see the LICENSE.md file for details.

--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ const rateLimit = require('express-rate-limit');
 
 const app = express();
 const port = 1997;
-const videoFolder = path.join(__dirname, 'videos'); // Correct path to 'videos' folder
+const videoFolder = path.join(__dirname, 'videos');
+const configPath = path.join(__dirname, 'config.json');
+const config = require(configPath);
+const { buildPriorityList, createVideoEntry, isVideoFile, sortByDeterministicShuffle } = require('./lib/scheduling');
 
 app.use(cors());
 app.use(express.static('public'));
@@ -40,25 +43,31 @@ app.get('/videos', videosLimiter, async (req, res) => {
             return res.status(404).json({ error: 'Video folder not found' });
         }
 
-        const files = await fs.readdir(videoFolder);
-        const videoFiles = filterVideoFiles(files);
+        const scheduleDate = getScheduleDate(req);
+        const priorities = buildPriorityList({
+            date: scheduleDate,
+            namedDateIntervals: config.namedDateIntervals,
+            namedTimeIntervals: config.namedTimeIntervals,
+        });
 
-        if (videoFiles.length === 0) {
-            console.warn('No videos found in the folder.');
+        const collectedVideos = await collectVideos(videoFolder, priorities);
+        if (collectedVideos.length === 0) {
+            console.warn('No videos found in the configured folders.');
             return res.status(404).json({ error: 'No videos available' });
         }
 
-        res.json(videoFiles);
+        const shuffledVideos = sortByDeterministicShuffle(collectedVideos, scheduleDate);
+        res.json({
+            date: scheduleDate.toISOString(),
+            priorities,
+            total: shuffledVideos.length,
+            videos: shuffledVideos,
+        });
     } catch (error) {
         console.error('Error reading video folder:', error);
         res.status(500).json({ error: 'Could not fetch videos' });
     }
 });
-
-function filterVideoFiles(files) {
-    const videoExtensions = ['.mp4', '.avi', '.mkv', '.webm'];
-    return files.filter(file => videoExtensions.some(ext => file.endsWith(ext)));
-}
 
 const server = app.listen(port, () => {
     console.log(`Server is running at http://localhost:${port}`);
@@ -81,5 +90,68 @@ app.use((req, res) => {
     res.status(404).send('Not Found');
 });
 
-const configPath = path.join(__dirname, 'config.json');
-const config = require(configPath);
+async function collectVideos(rootFolder, priorities) {
+    const results = [];
+    const seen = new Set();
+
+    for (const priority of priorities) {
+        const folderPath = path.join(rootFolder, priority);
+        const entries = await readVideosFromFolder(folderPath, priority);
+        for (const entry of entries) {
+            if (!seen.has(entry.relativePath)) {
+                seen.add(entry.relativePath);
+                results.push(entry);
+            }
+        }
+    }
+
+    return results;
+}
+
+async function readVideosFromFolder(folderPath, relativeBase) {
+    try {
+        const stats = await fs.stat(folderPath);
+        if (!stats.isDirectory()) {
+            return [];
+        }
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return [];
+        }
+        throw error;
+    }
+
+    return walkVideoFiles(folderPath, relativeBase);
+}
+
+async function walkVideoFiles(folderPath, relativeBase) {
+    const entries = await fs.readdir(folderPath, { withFileTypes: true });
+    const videos = [];
+
+    for (const entry of entries) {
+        const entryPath = path.join(folderPath, entry.name);
+        const relativePath = path.join(relativeBase, entry.name);
+        if (entry.isDirectory()) {
+            const nestedVideos = await walkVideoFiles(entryPath, relativePath);
+            videos.push(...nestedVideos);
+        } else if (entry.isFile() && isVideoFile(entry.name)) {
+            videos.push(createVideoEntry('/video', relativePath));
+        }
+    }
+
+    return videos;
+}
+
+function getScheduleDate(req) {
+    const override = req.query.at;
+    if (!override) {
+        return new Date();
+    }
+
+    const parsed = new Date(override);
+    if (Number.isNaN(parsed.getTime())) {
+        return new Date();
+    }
+
+    return parsed;
+}

--- a/lib/scheduling.js
+++ b/lib/scheduling.js
@@ -1,0 +1,109 @@
+const path = require('path');
+
+const DEFAULT_VIDEO_EXTENSIONS = ['.mp4', '.avi', '.mkv', '.webm'];
+
+function normalizeExtensions(extensions = DEFAULT_VIDEO_EXTENSIONS) {
+  return extensions.map((ext) => (ext.startsWith('.') ? ext.toLowerCase() : `.${ext.toLowerCase()}`));
+}
+
+function getDayOfYear(date) {
+  const start = new Date(date.getFullYear(), 0, 1);
+  const diff = date - start;
+  return Math.floor(diff / 86400000) + 1;
+}
+
+function parseMonthDay(value) {
+  const [month, day] = value.split('-').map(Number);
+  return { month, day };
+}
+
+function isDateWithinInterval(date, start, end) {
+  const year = date.getFullYear();
+  const startDate = new Date(year, start.month - 1, start.day);
+  const endDate = new Date(year, end.month - 1, end.day);
+
+  if (startDate <= endDate) {
+    return date >= startDate && date <= endDate;
+  }
+
+  return date >= startDate || date <= endDate;
+}
+
+function parseTime(value) {
+  const [hour, minute] = value.split(':').map(Number);
+  return hour * 60 + minute;
+}
+
+function isTimeWithinInterval(date, start, end) {
+  const currentMinutes = date.getHours() * 60 + date.getMinutes();
+  if (start <= end) {
+    return currentMinutes >= start && currentMinutes <= end;
+  }
+  return currentMinutes >= start || currentMinutes <= end;
+}
+
+function matchesNamedDateIntervals(date, intervals = []) {
+  return intervals.filter((interval) => {
+    const start = parseMonthDay(interval.start);
+    const end = parseMonthDay(interval.end);
+    return isDateWithinInterval(date, start, end);
+  });
+}
+
+function matchesNamedTimeIntervals(date, intervals = []) {
+  return intervals.filter((interval) => {
+    const start = parseTime(interval.start);
+    const end = parseTime(interval.end);
+    return isTimeWithinInterval(date, start, end);
+  });
+}
+
+function buildPriorityList({ date, namedDateIntervals, namedTimeIntervals }) {
+  const dateMatches = matchesNamedDateIntervals(date, namedDateIntervals).map((interval) => interval.name);
+  const timeMatches = matchesNamedTimeIntervals(date, namedTimeIntervals).map((interval) => interval.name);
+
+  return [
+    ...dateMatches.flatMap((dateName) => timeMatches.map((timeName) => `${dateName}/${timeName}`)),
+    ...dateMatches,
+    ...timeMatches,
+    'default',
+  ];
+}
+
+function isVideoFile(filename, extensions = DEFAULT_VIDEO_EXTENSIONS) {
+  const normalizedExtensions = normalizeExtensions(extensions);
+  return normalizedExtensions.some((extension) => filename.toLowerCase().endsWith(extension));
+}
+
+function toVideoUrl(baseRoute, relativePath) {
+  const normalized = relativePath.split(path.sep).join('/');
+  const encoded = normalized
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `${baseRoute}/${encoded}`;
+}
+
+function createVideoEntry(baseRoute, relativePath) {
+  const filename = path.basename(relativePath);
+  return {
+    filename,
+    relativePath,
+    url: toVideoUrl(baseRoute, relativePath),
+  };
+}
+
+function sortByDeterministicShuffle(videos, date = new Date()) {
+  const daySeed = getDayOfYear(date);
+  return [...videos]
+    .map((video, index) => ({ video, score: ((index + 1) * 9301 + daySeed * 49297) % 233280 }))
+    .sort((a, b) => a.score - b.score)
+    .map((entry) => entry.video);
+}
+
+module.exports = {
+  buildPriorityList,
+  createVideoEntry,
+  isVideoFile,
+  sortByDeterministicShuffle,
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "node index.js"
   },
   "keywords": [],

--- a/public/scripts/playVideos.js
+++ b/public/scripts/playVideos.js
@@ -13,7 +13,8 @@ async function fetchAndShuffleVideos() {
     if (!response.ok) {
       throw new Error('Failed to fetch videos from the server');
     }
-    const videos = await response.json();
+    const payload = await response.json();
+    const videos = Array.isArray(payload) ? payload : payload.videos;
     if (!Array.isArray(videos) || videos.length === 0) {
       throw new Error('No videos available');
     }
@@ -30,7 +31,12 @@ async function fetchAndShuffleVideos() {
  * @returns {Array} - The shuffled array.
  */
 function shuffleArray(array) {
-  return array.sort(() => Math.random() - 0.5);
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
 }
 
 /**
@@ -43,17 +49,44 @@ function playNextVideo() {
   }
 
   const currentVideo = videoQueue[currentIndex];
-  videoPlayer.src({ src: `/video/${encodeURIComponent(currentVideo)}`, type: 'video/mp4' });
+  const videoSource = typeof currentVideo === 'string' ? `/video/${encodeURI(currentVideo)}` : currentVideo.url;
+  const videoName = typeof currentVideo === 'string' ? currentVideo : currentVideo.filename;
+  videoPlayer.src({
+    src: videoSource,
+    type: getMimeType(videoName),
+  });
   videoPlayer.play();
 
   currentIndex = (currentIndex + 1) % videoQueue.length;
 }
 
 /**
+ * Get a basic MIME type for the video file.
+ * @param {string} filename
+ * @returns {string}
+ */
+function getMimeType(filename) {
+  const extension = filename.split('.').pop()?.toLowerCase();
+  switch (extension) {
+    case 'webm':
+      return 'video/webm';
+    case 'mkv':
+      return 'video/x-matroska';
+    case 'avi':
+      return 'video/x-msvideo';
+    case 'mp4':
+    default:
+      return 'video/mp4';
+  }
+}
+
+/**
  * Handle video playback errors by skipping to the next video.
  */
 function handleVideoError() {
-  console.error(`Error loading video: ${videoQueue[currentIndex]}`);
+  const currentVideo = videoQueue[currentIndex];
+  const videoName = typeof currentVideo === 'string' ? currentVideo : currentVideo.filename;
+  console.error(`Error loading video: ${videoName}`);
   playNextVideo();
 }
 

--- a/test/scheduling.test.js
+++ b/test/scheduling.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildPriorityList,
+  createVideoEntry,
+  isVideoFile,
+  sortByDeterministicShuffle,
+} = require('../lib/scheduling');
+
+test('buildPriorityList orders date/time priorities and includes default', () => {
+  const date = new Date('2024-12-24T20:00:00.000Z');
+  const priorities = buildPriorityList({
+    date,
+    namedDateIntervals: [{ name: 'natale', start: '12-01', end: '12-26' }],
+    namedTimeIntervals: [{ name: 'sera', start: '18:00', end: '21:59' }],
+  });
+
+  assert.deepEqual(priorities, ['natale/sera', 'natale', 'sera', 'default']);
+});
+
+test('isVideoFile matches common video extensions', () => {
+  assert.equal(isVideoFile('movie.mp4'), true);
+  assert.equal(isVideoFile('movie.MKV'), true);
+  assert.equal(isVideoFile('document.pdf'), false);
+});
+
+test('createVideoEntry builds encoded URLs', () => {
+  const entry = createVideoEntry('/video', 'sera/festività video.mp4');
+  assert.equal(entry.filename, 'festività video.mp4');
+  assert.equal(entry.relativePath, 'sera/festività video.mp4');
+  assert.equal(entry.url, '/video/sera/festivit%C3%A0%20video.mp4');
+});
+
+test('sortByDeterministicShuffle is deterministic per date', () => {
+  const date = new Date('2024-11-01T10:00:00.000Z');
+  const videos = [{ filename: 'a' }, { filename: 'b' }, { filename: 'c' }];
+
+  const first = sortByDeterministicShuffle(videos, date).map((video) => video.filename);
+  const second = sortByDeterministicShuffle(videos, date).map((video) => video.filename);
+
+  assert.deepEqual(first, second);
+});


### PR DESCRIPTION
### Motivation
- Enable FratchTV to choose videos from folders that match the current date/time (seasons, holidays, time-of-day) so playback can be prioritized by context. 
- Provide deterministic daily shuffling so playback order is repeatable per day while still appearing random. 
- Allow local development and automated verification without Docker by adding a simple test suite and local run instructions. 

### Description
- Added `lib/scheduling.js` which implements interval matching, priority list building, video file detection, encoded URL creation, and a deterministic per-day shuffle (`buildPriorityList`, `isVideoFile`, `createVideoEntry`, `sortByDeterministicShuffle`).
- Updated `index.js` to load `config.json`, compute schedule priorities for a request (optionally overrideable via the `?at=` query), walk `videos/` folders in priority order, deduplicate results, and return a structured payload `{ date, priorities, total, videos }`.
- Updated client `public/scripts/playVideos.js` to accept the structured payload, support both string and object video entries, improve shuffling (Fisher–Yates), and choose MIME type per file name for more robust playback.
- Documentation and tooling updates: updated `README.md` with local (no-Docker) run instructions and scheduling folder conventions, added `test/scheduling.test.js`, enabled `npm test` to run Node's test runner, and adjusted `.gitignore`.

### Testing
- Ran `npm test` which executed the Node-based suite in `test/scheduling.test.js` and all tests passed (4/4).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a6453a70832d85837985e75ebe0d)